### PR TITLE
Improve logging in the Kubernetes event source

### DIFF
--- a/src/Kubernetes/Streaming/Sources/KubernetesResourceEventSource.cs
+++ b/src/Kubernetes/Streaming/Sources/KubernetesResourceEventSource.cs
@@ -118,7 +118,7 @@ namespace Snd.Sdk.Kubernetes.Streaming.Sources
             {
                 Emit(kubernetesResourceEventSource.Out, tuple);
             }
-            
+
             private void OnWatcherClose()
             {
                 this.kubernetesResourceEventSource.logger?.LogInformation("Watcher completed");


### PR DESCRIPTION
Follow-up for #33

Improve logging and dispose watcher before the stage is completed