### PR TITLE
Add Assembly-based environment variable functions

### DIFF
--- a/src/Hosting/EnvironmentExtensions.cs
+++ b/src/Hosting/EnvironmentExtensions.cs
@@ -43,13 +43,13 @@ public static class EnvironmentExtensions
     /// <returns></returns>
     public static void SetDomainEnvironmentVariable(string varName, string varValue) =>
         Environment.SetEnvironmentVariable($"{AppDomain.CurrentDomain.FriendlyName.ToUpperInvariant()}__{varName}", varValue);
-    
+
     /// <summary>
     /// Returns the name prefix used for domain variables.
     /// </summary>
     /// <returns></returns>
     public static string GetDomainVariablePrefix() => $"{AppDomain.CurrentDomain.FriendlyName.ToUpperInvariant()}__";
-    
+
     /// <summary>
     /// Returns the name prefix used for assembly variables.
     /// </summary>
@@ -58,6 +58,6 @@ public static class EnvironmentExtensions
     {
         var name = Assembly.GetExecutingAssembly().GetName().Name ??
                    throw new InvalidOperationException("Assembly name not found.");
-            return $"{name.ToUpperInvariant()}__";
+        return $"{name.ToUpperInvariant()}__";
     }
 }

--- a/src/Hosting/EnvironmentExtensions.cs
+++ b/src/Hosting/EnvironmentExtensions.cs
@@ -54,5 +54,10 @@ public static class EnvironmentExtensions
     /// Returns the name prefix used for assembly variables.
     /// </summary>
     /// <returns></returns>
-    public static string GetAssemblyVariablePrefix() => $"{Assembly.GetExecutingAssembly().GetName().Name?.ToUpperInvariant()}__";
+    public static string GetAssemblyVariablePrefix()
+    {
+        var name = Assembly.GetExecutingAssembly().GetName().Name ??
+                   throw new InvalidOperationException("Assembly name not found.");
+            return $"{name.ToUpperInvariant()}__";
+    }
 }

--- a/src/Hosting/EnvironmentExtensions.cs
+++ b/src/Hosting/EnvironmentExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Reflection;
 
 namespace Snd.Sdk.Hosting;
 
@@ -17,6 +18,24 @@ public static class EnvironmentExtensions
         Environment.GetEnvironmentVariable($"{AppDomain.CurrentDomain.FriendlyName.ToUpperInvariant()}__{varName}") ?? defaultValue;
 
     /// <summary>
+    /// Sets the environment variable bound to this assembly domain.
+    /// </summary>
+    /// <param name="varName">Name of environment variable bound to Assembly to set.</param>
+    /// <param name="varValue">Value of environment variable bound to Assembly to set.</param>
+    /// <returns></returns>
+    public static void SetAssemblyEnvironmentVariable(string varName, string varValue) =>
+        Environment.SetEnvironmentVariable($"{GetAssemblyVariablePrefix()}{varName}", varValue);
+
+    /// <summary>
+    /// Read environment variable bound to this assembly domain.
+    /// </summary>
+    /// <param name="varName">Name of environment variable bound to Assembly to read.</param>
+    /// <param name="defaultValue">Optional default value to provide.</param> 
+    /// <returns></returns>
+    public static string GetAssemblyEnvironmentVariable(string varName, string defaultValue = "") =>
+        Environment.GetEnvironmentVariable($"{GetAssemblyVariablePrefix()}{varName}") ?? defaultValue;
+
+    /// <summary>
     /// Sets the environment variable bound to this application domain.
     /// </summary>
     /// <param name="varName">Name of environment variable bound to AppDomain to set.</param>
@@ -24,10 +43,16 @@ public static class EnvironmentExtensions
     /// <returns></returns>
     public static void SetDomainEnvironmentVariable(string varName, string varValue) =>
         Environment.SetEnvironmentVariable($"{AppDomain.CurrentDomain.FriendlyName.ToUpperInvariant()}__{varName}", varValue);
-
+    
     /// <summary>
     /// Returns the name prefix used for domain variables.
     /// </summary>
     /// <returns></returns>
     public static string GetDomainVariablePrefix() => $"{AppDomain.CurrentDomain.FriendlyName.ToUpperInvariant()}__";
+    
+    /// <summary>
+    /// Returns the name prefix used for assembly variables.
+    /// </summary>
+    /// <returns></returns>
+    public static string GetAssemblyVariablePrefix() => $"{Assembly.GetExecutingAssembly().GetName().Name?.ToUpperInvariant()}__";
 }


### PR DESCRIPTION
Part of the REST API stream.

We need to add assembly-based environment variable names to use them in Arcane.Operator and Arcane stream runners.