### PR TITLE
Implement List operations for Amazon S3 Writer

### DIFF
--- a/src/SnD.Sdk/SnD.Sdk.csproj
+++ b/src/SnD.Sdk/SnD.Sdk.csproj
@@ -42,10 +42,6 @@
     </ItemGroup>
 
     <ItemGroup>
-        <Folder Include="SnD.Sdk"/>
-    </ItemGroup>
-
-    <ItemGroup>
         <ProjectReference Include="../SnD.Sdk.Extensions.Environment/SnD.Sdk.Extensions.Environment.csproj"/>
     </ItemGroup>
 

--- a/src/SnD.Sdk/Storage/Amazon/AmazonBlobStorageClient.cs
+++ b/src/SnD.Sdk/Storage/Amazon/AmazonBlobStorageClient.cs
@@ -1,6 +1,9 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
+using Akka;
+using Akka.Streams.Dsl;
 using Amazon.S3;
 using Amazon.S3.Model;
 using Microsoft.Extensions.Logging;
@@ -8,6 +11,7 @@ using Snd.Sdk.Helpers;
 using Snd.Sdk.Tasks;
 using Snd.Sdk.Storage.Base;
 using Snd.Sdk.Storage.Models;
+using Snd.Sdk.Storage.Models.BlobPath;
 
 namespace Snd.Sdk.Storage.Amazon;
 
@@ -15,17 +19,17 @@ namespace Snd.Sdk.Storage.Amazon;
 /// Blob Service implementation for S3-compatible object storage.
 /// Blob path for this service should be in format s3://bucket-name/path
 /// </summary>
-public class AmazonBlobStorageWriter : IBlobStorageWriter
+public class AmazonBlobStorageClient : IBlobStorageWriter, IBlobStorageListService
 {
     private readonly IAmazonS3 client;
-    private readonly ILogger<AmazonBlobStorageWriter> logger;
+    private readonly ILogger<AmazonBlobStorageClient> logger;
 
     /// <summary>
     /// Creates a new instance of S3BlobStorageService.
     /// </summary>
     /// <param name="client">Authenticated S3 AWS client instance</param>
     /// <param name="logger">Logger</param>
-    public AmazonBlobStorageWriter(IAmazonS3 client, ILogger<AmazonBlobStorageWriter> logger)
+    public AmazonBlobStorageClient(IAmazonS3 client, ILogger<AmazonBlobStorageClient> logger)
     {
         this.client = client;
         this.logger = logger;
@@ -77,4 +81,54 @@ public class AmazonBlobStorageWriter : IBlobStorageWriter
             return default;
         });
     }
+
+    /// <inheritdoc/>
+    public Source<StoredBlob, NotUsed> ListBlobs(string blobPath)
+    {
+        var path = blobPath.AsAmazonS3Path();
+        return Source.From(() => this.GetObjectsPaginator(path)).Select(this.MapToStoredBlob);
+    }
+
+    /// <inheritdoc/>
+    public IEnumerable<StoredBlob> ListBlobsAsEnumerable(string blobPath)
+    {
+        var path = blobPath.AsAmazonS3Path();
+        var request = new ListObjectsV2Request
+        {
+            BucketName = path.Bucket,
+            Prefix = path.ObjectKey
+        };
+        do
+        {
+            var response = this.client.ListObjectsV2Async(request).GetAwaiter().GetResult();
+            foreach(var s3Object in response.S3Objects)
+            {
+                yield return this.MapToStoredBlob(s3Object);
+            }
+            request.ContinuationToken = response.NextContinuationToken;
+        }
+        while (request.ContinuationToken != null);
+    }
+    
+    private StoredBlob MapToStoredBlob(S3Object arg)
+    {
+        return new StoredBlob
+        {
+            Name = arg.Key,
+            LastModified = arg.LastModified,
+            ContentLength = arg.Size,
+            ContentHash = arg.ETag
+        };
+    }
+
+    private IAsyncEnumerable<S3Object> GetObjectsPaginator(AmazonS3StoragePath path)
+    {
+        var paginator = this.client.Paginators.ListObjectsV2(new ListObjectsV2Request
+        {
+            BucketName = path.Bucket,
+            Prefix = path.ObjectKey
+        });
+        return paginator.S3Objects;
+    }
+
 }

--- a/src/SnD.Sdk/Storage/Amazon/AmazonBlobStorageClient.cs
+++ b/src/SnD.Sdk/Storage/Amazon/AmazonBlobStorageClient.cs
@@ -101,7 +101,7 @@ public class AmazonBlobStorageClient : IBlobStorageWriter, IBlobStorageListServi
         do
         {
             var response = this.client.ListObjectsV2Async(request).GetAwaiter().GetResult();
-            foreach(var s3Object in response.S3Objects)
+            foreach (var s3Object in response.S3Objects)
             {
                 yield return this.MapToStoredBlob(s3Object);
             }
@@ -109,7 +109,7 @@ public class AmazonBlobStorageClient : IBlobStorageWriter, IBlobStorageListServi
         }
         while (request.ContinuationToken != null);
     }
-    
+
     private StoredBlob MapToStoredBlob(S3Object arg)
     {
         return new StoredBlob

--- a/src/SnD.Sdk/Storage/Amazon/AmazonBlobStorageClient.cs
+++ b/src/SnD.Sdk/Storage/Amazon/AmazonBlobStorageClient.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Threading.Tasks;
 using Akka;
@@ -83,6 +84,7 @@ public class AmazonBlobStorageClient : IBlobStorageWriter, IBlobStorageListServi
     }
 
     /// <inheritdoc/>
+    [ExcludeFromCodeCoverage(Justification = "Trivial")]
     public Source<StoredBlob, NotUsed> ListBlobs(string blobPath)
     {
         var path = blobPath.AsAmazonS3Path();
@@ -90,6 +92,7 @@ public class AmazonBlobStorageClient : IBlobStorageWriter, IBlobStorageListServi
     }
 
     /// <inheritdoc/>
+    [ExcludeFromCodeCoverage(Justification = "Trivial")]
     public IEnumerable<StoredBlob> ListBlobsAsEnumerable(string blobPath)
     {
         var path = blobPath.AsAmazonS3Path();
@@ -110,6 +113,7 @@ public class AmazonBlobStorageClient : IBlobStorageWriter, IBlobStorageListServi
         while (request.ContinuationToken != null);
     }
 
+    [ExcludeFromCodeCoverage(Justification = "Trivial")]
     private StoredBlob MapToStoredBlob(S3Object arg)
     {
         return new StoredBlob
@@ -121,6 +125,7 @@ public class AmazonBlobStorageClient : IBlobStorageWriter, IBlobStorageListServi
         };
     }
 
+    [ExcludeFromCodeCoverage(Justification = "Trivial")]
     private IAsyncEnumerable<S3Object> GetObjectsPaginator(AmazonS3StoragePath path)
     {
         var paginator = this.client.Paginators.ListObjectsV2(new ListObjectsV2Request

--- a/src/SnD.Sdk/Storage/Base/IBlobStorageListService.cs
+++ b/src/SnD.Sdk/Storage/Base/IBlobStorageListService.cs
@@ -10,7 +10,6 @@ namespace Snd.Sdk.Storage.Base;
 /// </summary>
 public interface IBlobStorageListService
 {
-    
     /// <summary>
     /// Stream blob item metadata for blobs under provided path.
     /// </summary>

--- a/src/SnD.Sdk/Storage/Base/IBlobStorageListService.cs
+++ b/src/SnD.Sdk/Storage/Base/IBlobStorageListService.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Generic;
+using Akka;
+using Akka.Streams.Dsl;
+using Snd.Sdk.Storage.Models;
+
+namespace Snd.Sdk.Storage.Base;
+
+/// <summary>
+/// Binary object storage listing abstraction.
+/// </summary>
+public interface IBlobStorageListService
+{
+    
+    /// <summary>
+    /// Stream blob item metadata for blobs under provided path.
+    /// </summary>
+    /// <param name="blobPath">Path to list.</param>
+    /// <returns></returns>
+    Source<StoredBlob, NotUsed> ListBlobs(string blobPath);
+
+    /// <summary>
+    /// Retrieve blob item metadata for blobs under provided path, as an enumerable.
+    /// </summary>
+    /// <param name="blobPath">Path to list.</param>
+    /// <returns></returns>
+    IEnumerable<StoredBlob> ListBlobsAsEnumerable(string blobPath);
+}

--- a/src/SnD.Sdk/Storage/Base/IBlobStorageService.cs
+++ b/src/SnD.Sdk/Storage/Base/IBlobStorageService.cs
@@ -1,10 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Akka;
-using Akka.Streams.Dsl;
 using Snd.Sdk.Storage.Base.Streaming;
-using Snd.Sdk.Storage.Models;
 
 namespace Snd.Sdk.Storage.Base;
 
@@ -13,7 +10,8 @@ namespace Snd.Sdk.Storage.Base;
 /// </summary>
 public interface IBlobStorageService : IBlobStorageReader,
     IBlobStorageWriter,
-    IBlobStreamWriter
+    IBlobStreamWriter,
+    IBlobStorageListService
 {
     /// <summary>
     /// Reads blob metadata for the specified blob.
@@ -57,18 +55,4 @@ public interface IBlobStorageService : IBlobStorageReader,
     /// <param name="kwOptions">Additional key-value arguments for URI generator.</param>
     /// <returns></returns>
     Uri GetBlobUri(string blobPath, string blobName, params ValueTuple<string, object>[] kwOptions);
-
-    /// <summary>
-    /// Stream blob item metadata for blobs under provided path.
-    /// </summary>
-    /// <param name="blobPath">Path to list.</param>
-    /// <returns></returns>
-    Source<StoredBlob, NotUsed> ListBlobs(string blobPath);
-
-    /// <summary>
-    /// Retrieve blob item metadata for blobs under provided path, as an enumerable.
-    /// </summary>
-    /// <param name="blobPath">Path to list.</param>
-    /// <returns></returns>
-    IEnumerable<StoredBlob> ListBlobsAsEnumerable(string blobPath);
 }

--- a/src/SnD.Sdk/Storage/Providers/AmazonStorageServiceProvider.cs
+++ b/src/SnD.Sdk/Storage/Providers/AmazonStorageServiceProvider.cs
@@ -32,7 +32,7 @@ namespace Snd.Sdk.Storage.Providers
             };
 
             services.AddSingleton<IAmazonS3>(new AmazonS3Client(awsConfig.AccessKey, awsConfig.SecretKey, clientConfig));
-            return services.AddSingleton<IBlobStorageWriter, AmazonBlobStorageWriter>();
+            return services.AddSingleton<IBlobStorageWriter, AmazonBlobStorageClient>();
         }
     }
 }


### PR DESCRIPTION
Part of https://github.com/SneaksAndData/arcane-framework/issues/69

Implemented: 
- Listing operations for `AmazonBlobStorageClient`.
- Listing operations have been extracted from the `IBlobStorageService` interface to the separate interface `IBlobStorageListService`.

Additional changes:
- The `AmazonBlobStorageWriter` class has been renamed to `AmazonBlobStorageClient`.

This PR is part of the implementation of the `IBlobStorageService` interface for the `AmazonBlobStorageClient` class. For now, only list operations are supported since they are required to continue work on https://github.com/SneaksAndData/arcane-framework/pull/75.

Other operations will be implemented in the next Pull Requests.