### PR TITLE
Implement Read operations for Amazon S3 Client

### DIFF
--- a/src/SnD.Sdk/Storage/Base/IBlobStorageService.cs
+++ b/src/SnD.Sdk/Storage/Base/IBlobStorageService.cs
@@ -30,14 +30,6 @@ public interface IBlobStorageService : IBlobStorageReader,
     Task<IDictionary<string, string>> GetBlobMetadataAsync(string blobPath, string blobName);
 
     /// <summary>
-    /// Deletes a blob.
-    /// </summary>
-    /// <param name="blobPath">Blob path.</param>
-    /// <param name="blobName">Blob name.</param>
-    /// <returns></returns>
-    Task<bool> RemoveBlob(string blobPath, string blobName);
-
-    /// <summary>
     /// Moves a blob from one container to another, in the same storage account.
     /// </summary>
     /// <param name="sourcePath">Path to a source blob.</param>

--- a/src/SnD.Sdk/Storage/Base/IBlobStorageWriter.cs
+++ b/src/SnD.Sdk/Storage/Base/IBlobStorageWriter.cs
@@ -28,4 +28,11 @@ public interface IBlobStorageWriter
     /// <returns></returns>
     Task<UploadedBlob> SaveTextAsBlob(string text, string blobPath, string blobName);
 
+    /// <summary>
+    /// Deletes a blob.
+    /// </summary>
+    /// <param name="blobPath">Blob path.</param>
+    /// <param name="blobName">Blob name.</param>
+    /// <returns></returns>
+    Task<bool> RemoveBlob(string blobPath, string blobName);
 }

--- a/src/SnD.Sdk/Storage/Providers/AmazonStorageServiceProvider.cs
+++ b/src/SnD.Sdk/Storage/Providers/AmazonStorageServiceProvider.cs
@@ -32,7 +32,7 @@ namespace Snd.Sdk.Storage.Providers
             };
 
             services.AddSingleton<IAmazonS3>(new AmazonS3Client(awsConfig.AccessKey, awsConfig.SecretKey, clientConfig));
-            return services.AddSingleton<IBlobStorageWriter, AmazonBlobStorageClient>();
+            return services.AddSingleton<IBlobStorageWriter, AmazonBlobStorageService>();
         }
     }
 }


### PR DESCRIPTION
Part of Part of https://github.com/SneaksAndData/arcane-framework/issues/69

Implemented:
- The `IBlobStorageReader` interface for `AmazonBlobStorageClient`.
- The `RemoveBlob` method was moved from the `IBlobStorageService` interface to the `IBlobStorageWriter` interface.

Additional chages:
- The `AmazonBlobStorageClient` class was renamed to `AmazonBlobStorageService` to maintain naming consistency with the `AzureBlobStorageService` class.