### PR TITLE
Add the `ToHdfsPath` method to `IStoragePath` interface

### DIFF
--- a/src/SnD.Sdk/Storage/Models/Base/BlobPath.cs
+++ b/src/SnD.Sdk/Storage/Models/Base/BlobPath.cs
@@ -16,4 +16,10 @@ public interface IStoragePath
     /// Relative path to an object in the blob storage
     /// </summary>
     public string ObjectKey { get; }
+    
+    /// <summary>
+    /// Converts the given path to HDFS path string.
+    /// </summary>
+    /// <returns>String representing HDFS path information</returns>
+    public string ToHdfsPath();
 }

--- a/src/SnD.Sdk/Storage/Models/Base/BlobPath.cs
+++ b/src/SnD.Sdk/Storage/Models/Base/BlobPath.cs
@@ -16,7 +16,7 @@ public interface IStoragePath
     /// Relative path to an object in the blob storage
     /// </summary>
     public string ObjectKey { get; }
-    
+
     /// <summary>
     /// Converts the given path to HDFS path string.
     /// </summary>

--- a/src/SnD.Sdk/Storage/Models/BlobPath/AdlsGen2Path.cs
+++ b/src/SnD.Sdk/Storage/Models/BlobPath/AdlsGen2Path.cs
@@ -33,7 +33,7 @@ public record AdlsGen2Path : IStoragePath
             ObjectKey = $"{this.ObjectKey}/{keyName}"
         };
     }
-    
+
     /// <inheritdoc cref="IStoragePath.ToHdfsPath"/>
     public string ToHdfsPath() => $"abfss://{this.Container}@{this.ObjectKey}";
 

--- a/src/SnD.Sdk/Storage/Models/BlobPath/AdlsGen2Path.cs
+++ b/src/SnD.Sdk/Storage/Models/BlobPath/AdlsGen2Path.cs
@@ -10,6 +10,7 @@ namespace Snd.Sdk.Storage.Models.BlobPath;
 public record AdlsGen2Path : IStoragePath
 {
     private const string matchRegex = @"^(abfss://)?(?<container>[^@:/]+)@(?<key>.+)$";
+    private readonly string objectKey;
 
     /// <summary>
     /// Blob container name
@@ -18,7 +19,11 @@ public record AdlsGen2Path : IStoragePath
 
 
     /// <inheritdoc cref="IStoragePath"/>
-    public string ObjectKey { get; init; }
+    public string ObjectKey
+    {
+        get => this.objectKey;
+        init => this.objectKey = Regex.Replace(value.Trim('/'), "/+", "/");
+    }
 
     /// <inheritdoc cref="IStoragePath"/>
     public IStoragePath Join(string keyName)
@@ -28,6 +33,9 @@ public record AdlsGen2Path : IStoragePath
             ObjectKey = $"{this.ObjectKey}/{keyName}"
         };
     }
+    
+    /// <inheritdoc cref="IStoragePath.ToHdfsPath"/>
+    public string ToHdfsPath() => $"abfss://{this.Container}@{this.ObjectKey}";
 
     /// <summary>
     /// Converts HDFS path to an instance of <see cref="AdlsGen2Path"/>.

--- a/test/Storage/AldsGen2PathTests.cs
+++ b/test/Storage/AldsGen2PathTests.cs
@@ -5,52 +5,52 @@ namespace Snd.Sdk.Tests.Storage;
 
 public class AdlsGen2PathTests
 {
-    
+
     private const string path = "abfss://container@folder1/folder2/file.txt";
-    
+
     [Fact]
     public static void CanParsePath()
     {
         // Act
         var storagePath = new AdlsGen2Path(path);
-        
+
         // Assert
         Assert.Equal("container", storagePath.Container);
         Assert.Equal("folder1/folder2/file.txt", storagePath.ObjectKey);
     }
-    
+
     [Fact]
     public static void CanSerializePath()
     {
         // Act
         var storagePath = new AdlsGen2Path(path);
-        
+
         // Assert
         Assert.Equal(path, storagePath.ToHdfsPath());
     }
-    
+
     [Fact]
     public static void CanJoinPath()
     {
         // Arrange
         const string pathStart = "abfss://container@/";
-        
+
         // Act
         var storagePath = new AdlsGen2Path(pathStart).Join("/folder1/folder2/file.txt");
-        
+
         // Assert
         Assert.Equal(path, storagePath.ToHdfsPath());
     }
-    
+
     [Fact]
     public static void TrimsDuplicatedSlashes()
     {
         // Arrange
         const string pathStart = "abfss://container@/";
-        
+
         // Act
         var storagePath = new AdlsGen2Path(pathStart).Join("/folder1///folder2/file.txt");
-        
+
         // Assert
         Assert.Equal(path, storagePath.ToHdfsPath());
     }

--- a/test/Storage/AldsGen2PathTests.cs
+++ b/test/Storage/AldsGen2PathTests.cs
@@ -1,0 +1,57 @@
+﻿using Snd.Sdk.Storage.Models.BlobPath;
+using Xunit;
+
+namespace Snd.Sdk.Tests.Storage;
+
+public class AdlsGen2PathTests
+{
+    
+    private const string path = "abfss://container@folder1/folder2/file.txt";
+    
+    [Fact]
+    public static void CanParsePath()
+    {
+        // Act
+        var storagePath = new AdlsGen2Path(path);
+        
+        // Assert
+        Assert.Equal("container", storagePath.Container);
+        Assert.Equal("folder1/folder2/file.txt", storagePath.ObjectKey);
+    }
+    
+    [Fact]
+    public static void CanSerializePath()
+    {
+        // Act
+        var storagePath = new AdlsGen2Path(path);
+        
+        // Assert
+        Assert.Equal(path, storagePath.ToHdfsPath());
+    }
+    
+    [Fact]
+    public static void CanJoinPath()
+    {
+        // Arrange
+        const string pathStart = "abfss://container@/";
+        
+        // Act
+        var storagePath = new AdlsGen2Path(pathStart).Join("/folder1/folder2/file.txt");
+        
+        // Assert
+        Assert.Equal(path, storagePath.ToHdfsPath());
+    }
+    
+    [Fact]
+    public static void TrimsDuplicatedSlashes()
+    {
+        // Arrange
+        const string pathStart = "abfss://container@/";
+        
+        // Act
+        var storagePath = new AdlsGen2Path(pathStart).Join("/folder1///folder2/file.txt");
+        
+        // Assert
+        Assert.Equal(path, storagePath.ToHdfsPath());
+    }
+}

--- a/test/Storage/AmazonS3BlobStoragePathTests.cs
+++ b/test/Storage/AmazonS3BlobStoragePathTests.cs
@@ -5,56 +5,56 @@ namespace Snd.Sdk.Tests.Storage;
 
 public class AmazonS3BlobStoragePathTests
 {
-    
+
     [Fact]
     public static void CanParsePath()
     {
         // Arrange
         const string path = "s3a://bucket-name/folder1/folder2/file.txt";
-        
+
         // Act
         var storagePath = new AmazonS3StoragePath(path);
-        
+
         // Assert
         Assert.Equal("bucket-name", storagePath.Bucket);
         Assert.Equal("folder1/folder2/file.txt", storagePath.ObjectKey);
     }
-    
+
     [Fact]
     public static void CanSerializePath()
     {
         // Arrange
         const string path = "s3a://bucket-name/folder1/folder2/file.txt";
-        
+
         // Act
         var storagePath = new AmazonS3StoragePath(path);
-        
+
         // Assert
         Assert.Equal(path, storagePath.ToHdfsPath());
     }
-    
+
     [Fact]
     public static void CanJoinPath()
     {
         // Arrange
         const string path = "s3a://bucket-name/";
-        
+
         // Act
         var storagePath = new AmazonS3StoragePath(path).Join("/folder1/folder2/file.txt");
-        
+
         // Assert
         Assert.Equal("s3a://bucket-name/folder1/folder2/file.txt", storagePath.ToHdfsPath());
     }
-    
+
     [Fact]
     public static void TrimsDuplicatedSlashes()
     {
         // Arrange
         const string path = "s3a://bucket-name/";
-        
+
         // Act
         var storagePath = new AmazonS3StoragePath(path).Join("/folder1///folder2/file.txt");
-        
+
         // Assert
         Assert.Equal("s3a://bucket-name/folder1/folder2/file.txt", storagePath.ToHdfsPath());
     }

--- a/test/Storage/AmazonS3BlobStoragePathTests.cs
+++ b/test/Storage/AmazonS3BlobStoragePathTests.cs
@@ -1,0 +1,61 @@
+﻿using Snd.Sdk.Storage.Models.BlobPath;
+using Xunit;
+
+namespace Snd.Sdk.Tests.Storage;
+
+public class AmazonS3BlobStoragePathTests
+{
+    
+    [Fact]
+    public static void CanParsePath()
+    {
+        // Arrange
+        const string path = "s3a://bucket-name/folder1/folder2/file.txt";
+        
+        // Act
+        var storagePath = new AmazonS3StoragePath(path);
+        
+        // Assert
+        Assert.Equal("bucket-name", storagePath.Bucket);
+        Assert.Equal("folder1/folder2/file.txt", storagePath.ObjectKey);
+    }
+    
+    [Fact]
+    public static void CanSerializePath()
+    {
+        // Arrange
+        const string path = "s3a://bucket-name/folder1/folder2/file.txt";
+        
+        // Act
+        var storagePath = new AmazonS3StoragePath(path);
+        
+        // Assert
+        Assert.Equal(path, storagePath.ToHdfsPath());
+    }
+    
+    [Fact]
+    public static void CanJoinPath()
+    {
+        // Arrange
+        const string path = "s3a://bucket-name/";
+        
+        // Act
+        var storagePath = new AmazonS3StoragePath(path).Join("/folder1/folder2/file.txt");
+        
+        // Assert
+        Assert.Equal("s3a://bucket-name/folder1/folder2/file.txt", storagePath.ToHdfsPath());
+    }
+    
+    [Fact]
+    public static void TrimsDuplicatedSlashes()
+    {
+        // Arrange
+        const string path = "s3a://bucket-name/";
+        
+        // Act
+        var storagePath = new AmazonS3StoragePath(path).Join("/folder1///folder2/file.txt");
+        
+        // Assert
+        Assert.Equal("s3a://bucket-name/folder1/folder2/file.txt", storagePath.ToHdfsPath());
+    }
+}


### PR DESCRIPTION
Also, fixed path parsing behavior in edge cases

Part of https://github.com/SneaksAndData/arcane-framework/issues/62