### PR TITLE
Adding missing unit test for Pod Policy Failure Exit codes

### DIFF
--- a/test/Kubernetes/KubernetesApiExtensionsTests.cs
+++ b/test/Kubernetes/KubernetesApiExtensionsTests.cs
@@ -131,4 +131,24 @@ public class KubernetesApiExtensionsTests
             .Select(condition => condition.Status)
             .ToList());
     }
+
+    [Fact]
+    public void WithPodPolicyFailureExitCodes()
+    {
+        var job = new V1Job();
+
+        var actions = new Dictionary<string, List<int>>
+       {
+           { "Ignore", new List<int> {128 , 137, 139}}
+       };
+
+        var result = job.WithPodPolicyFailureExitCodes(actions);
+
+       foreach (var action in actions)
+       {
+           Assert.Contains(result.Spec.PodFailurePolicy.Rules, rule =>
+               rule.Action == action.Key &&
+               action.Value.All(exitCode => rule.OnExitCodes.Values.Contains(exitCode)));
+       }
+    }
 }

--- a/test/Kubernetes/KubernetesApiExtensionsTests.cs
+++ b/test/Kubernetes/KubernetesApiExtensionsTests.cs
@@ -132,15 +132,18 @@ public class KubernetesApiExtensionsTests
             .ToList());
     }
 
-    [Fact]
-    public void WithPodPolicyFailureExitCodes()
+    [Theory]
+    [InlineData("Ignore", new int[] { 128, 137, 139 })]
+    [InlineData("Restart", new int[] { 1, 2 })]
+    [InlineData("Fail", new int[] { 255 })]
+    public void WithPodPolicyFailureExitCodes(string actionName, int[] exitCodes)
     {
         var job = new V1Job();
 
         var actions = new Dictionary<string, List<int>>
-       {
-           { "Ignore", new List<int> {128 , 137, 139}}
-       };
+        {
+            { actionName, new List<int>(exitCodes) }
+        };
 
         var result = job.WithPodPolicyFailureExitCodes(actions);
 

--- a/test/Kubernetes/KubernetesApiExtensionsTests.cs
+++ b/test/Kubernetes/KubernetesApiExtensionsTests.cs
@@ -144,11 +144,11 @@ public class KubernetesApiExtensionsTests
 
         var result = job.WithPodPolicyFailureExitCodes(actions);
 
-       foreach (var action in actions)
-       {
-           Assert.Contains(result.Spec.PodFailurePolicy.Rules, rule =>
-               rule.Action == action.Key &&
-               action.Value.All(exitCode => rule.OnExitCodes.Values.Contains(exitCode)));
-       }
+        foreach (var action in actions)
+        {
+            Assert.Contains(result.Spec.PodFailurePolicy.Rules, rule =>
+                rule.Action == action.Key &&
+                action.Value.All(exitCode => rule.OnExitCodes.Values.Contains(exitCode)));
+        }
     }
 }


### PR DESCRIPTION
Adding missing unit test for Pod Policy Failure Exit codes that should have been added with its implementation.