### PR TITLE
[Bugfix] Fixing adding job pod Policy Failure "Ignore" for both DisruptionTarget and OnExitCodes rules

### DIFF
--- a/src/SnD.Sdk/Kubernetes/KubernetesApiExtensions.cs
+++ b/src/SnD.Sdk/Kubernetes/KubernetesApiExtensions.cs
@@ -576,6 +576,7 @@ namespace Snd.Sdk.Kubernetes
 
             job.Spec.PodFailurePolicy.Rules = (job.Spec.PodFailurePolicy.Rules ?? new List<V1PodFailurePolicyRule>())
                 .Concat(actions.Select(ConvertToFailurePolicyRule))
+                .Where(rule => rule.OnExitCodes != null)
                 .GroupBy(rule => rule.Action)
                 .Select(grp => grp.Aggregate(MergePodFailurePolicyRules))
                 .ToList();

--- a/test/Kubernetes/KubernetesApiExtensionsTests.cs
+++ b/test/Kubernetes/KubernetesApiExtensionsTests.cs
@@ -154,4 +154,24 @@ public class KubernetesApiExtensionsTests
                 action.Value.All(exitCode => rule.OnExitCodes.Values.Contains(exitCode)));
         }
     }
+
+    [Theory]
+    [InlineData("Ignore", new int[] { 128, 137, 139 })]
+    [InlineData("Fail", new int[] { 255 })]
+    public void WithPodPolicyFailureExitCodesAfterWithDisruptionTarget(string actionName, int[] exitCodes)
+    {
+        var job = new V1Job();
+
+        job = job.WithPodPolicyFailureDisruptionTarget();
+
+        var actions = new Dictionary<string, List<int>> { { actionName, new List<int>(exitCodes) } };
+        job = job.WithPodPolicyFailureDisruptionTarget().WithPodPolicyFailureExitCodes(actions);
+
+        foreach (var action in actions)
+        {
+            Assert.Contains(job.Spec.PodFailurePolicy.Rules, rule =>
+                rule.Action == action.Key &&
+                action.Value.All(exitCode => rule.OnExitCodes.Values.Contains(exitCode)));
+        }
+    }
 }


### PR DESCRIPTION
When using `job.WithPodPolicyFailureDisruptionTarget().WithPodPolicyFailureExitCodes(actions)`, in this order, the function `WithPodPolicyFailureExitCodes()` would try to aggregate Rules with the same action name. This is a problem when using the action "Ignore" since WithPodPolicyFailureDisruptionTarget() also uses it, triggering an exception.

## Changes
- Now `WithPodPolicyFailureExitCodes()` makes sure to rule out any rules without an `OnExitCodes`, when aggregating the same rules, avoiding this problem.

## Additional
- An unit test has been added to test this interaction.

