### PR TITLE
Do not remove duplicates in Amazon S3 Path

### DIFF
--- a/src/SnD.Sdk/Storage/Models/BlobPath/AdlsGen2Path.cs
+++ b/src/SnD.Sdk/Storage/Models/BlobPath/AdlsGen2Path.cs
@@ -10,7 +10,6 @@ namespace Snd.Sdk.Storage.Models.BlobPath;
 public record AdlsGen2Path : IStoragePath
 {
     private const string matchRegex = @"^(abfss://)?(?<container>[^@:/]+)@(?<key>.+)$";
-    private readonly string objectKey;
 
     /// <summary>
     /// Blob container name
@@ -19,23 +18,19 @@ public record AdlsGen2Path : IStoragePath
 
 
     /// <inheritdoc cref="IStoragePath"/>
-    public string ObjectKey
-    {
-        get => this.objectKey;
-        init => this.objectKey = Regex.Replace(value.Trim('/'), "/+", "/");
-    }
+    public string ObjectKey { get; init; }
 
     /// <inheritdoc cref="IStoragePath"/>
     public IStoragePath Join(string keyName)
     {
         return this with
         {
-            ObjectKey = $"{this.ObjectKey}/{keyName}"
+            ObjectKey = $"{this.ObjectKey.Trim('/')}/{keyName.Trim('/')}"
         };
     }
 
     /// <inheritdoc cref="IStoragePath.ToHdfsPath"/>
-    public string ToHdfsPath() => $"abfss://{this.Container}@{this.ObjectKey}";
+    public string ToHdfsPath() => $"abfss://{this.Container}@{this.ObjectKey.Trim('/')}";
 
     /// <summary>
     /// Converts HDFS path to an instance of <see cref="AdlsGen2Path"/>.

--- a/src/SnD.Sdk/Storage/Models/BlobPath/AmazonS3BlobPath.cs
+++ b/src/SnD.Sdk/Storage/Models/BlobPath/AmazonS3BlobPath.cs
@@ -27,7 +27,7 @@ public record AmazonS3StoragePath : IStoragePath
     {
         return this with
         {
-            ObjectKey = $"{this.ObjectKey}/{keyName.Trim('/')}"
+            ObjectKey = string.IsNullOrEmpty(this.ObjectKey) ? keyName : $"{this.ObjectKey}/{keyName}"
         };
     }
 
@@ -49,7 +49,7 @@ public record AmazonS3StoragePath : IStoragePath
         }
 
         this.Bucket = match.Groups["bucket"].Value;
-        this.ObjectKey = match.Groups["key"].Value;
+        this.ObjectKey = match.Groups["key"].Value.Trim('/');
     }
 
     /// <summary>

--- a/src/SnD.Sdk/Storage/Models/BlobPath/AmazonS3BlobPath.cs
+++ b/src/SnD.Sdk/Storage/Models/BlobPath/AmazonS3BlobPath.cs
@@ -9,8 +9,7 @@ namespace Snd.Sdk.Storage.Models.BlobPath;
 /// </summary>
 public record AmazonS3StoragePath : IStoragePath
 {
-    private const string matchRegex = "s3a://(?<bucket>[^/]+)/(?<key>.*)";
-    private readonly string objectKey;
+    private const string matchRegex = "s3a://(?<bucket>[^/]+)/?(?<key>.*)";
 
     /// <summary>
     /// Blob bucket name
@@ -18,11 +17,7 @@ public record AmazonS3StoragePath : IStoragePath
     public string Bucket { get; init; }
 
     /// <inheritdoc cref="IStoragePath.ObjectKey"/>
-    public string ObjectKey
-    {
-        get => this.objectKey;
-        init => this.objectKey = Regex.Replace(value.Trim('/'), "/+", "/");
-    }
+    public string ObjectKey { get; init; }
 
     /// <inheritdoc cref="IStoragePath.ToHdfsPath"/>
     public string ToHdfsPath() => $"s3a://{this.Bucket}/{this.ObjectKey}";
@@ -50,7 +45,7 @@ public record AmazonS3StoragePath : IStoragePath
 
         if (!match.Success)
         {
-            throw new ArgumentException($"An {nameof(AmazonS3StoragePath)} must be in the format s3a://bucket/path");
+            throw new ArgumentException($"An {nameof(AmazonS3StoragePath)} must be in the format s3a://bucket/path, but was: {hdfspath}");
         }
 
         this.Bucket = match.Groups["bucket"].Value;

--- a/test/SnD.Sdk.Tests.csproj
+++ b/test/SnD.Sdk.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 	<RootNamespace>SnD.Sdk.Tests</RootNamespace>
 
     <IsPackable>false</IsPackable>

--- a/test/Storage/AldsGen2PathTests.cs
+++ b/test/Storage/AldsGen2PathTests.cs
@@ -36,7 +36,7 @@ public class AdlsGen2PathTests
         const string pathStart = "abfss://container@/";
 
         // Act
-        var storagePath = new AdlsGen2Path(pathStart).Join("/folder1/folder2/file.txt");
+        var storagePath = new AdlsGen2Path(pathStart).Join("folder1/folder2/file.txt");
 
         // Assert
         Assert.Equal(path, storagePath.ToHdfsPath());
@@ -47,11 +47,12 @@ public class AdlsGen2PathTests
     {
         // Arrange
         const string pathStart = "abfss://container@/";
+        const string expected = "abfss://container@folder1///folder2/file.txt";
 
         // Act
         var storagePath = new AdlsGen2Path(pathStart).Join("/folder1///folder2/file.txt");
 
         // Assert
-        Assert.Equal(path, storagePath.ToHdfsPath());
+        Assert.Equal(expected, storagePath.ToHdfsPath());
     }
 }

--- a/test/Storage/AmazonS3BlobStoragePathTests.cs
+++ b/test/Storage/AmazonS3BlobStoragePathTests.cs
@@ -43,19 +43,23 @@ public class AmazonS3BlobStoragePathTests
         var storagePath = new AmazonS3StoragePath(path).Join("/folder1/folder2/file.txt");
 
         // Assert
-        Assert.Equal("s3a://bucket-name/folder1/folder2/file.txt", storagePath.ToHdfsPath());
+        Assert.Equal("s3a://bucket-name//folder1/folder2/file.txt", storagePath.ToHdfsPath());
     }
 
-    [Fact]
-    public static void TrimsDuplicatedSlashes()
+    [Theory]
+    [InlineData("s3a://bucket-name/", "/folder1///folder2/file.txt", "s3a://bucket-name//folder1///folder2/file.txt")]
+    [InlineData("s3a://bucket-name/", "folder1///folder2/file.txt", "s3a://bucket-name//folder1///folder2/file.txt")]
+    [InlineData("s3a://bucket-name", "folder1///folder2/file.txt", "s3a://bucket-name//folder1///folder2/file.txt")]
+    [InlineData("s3a://bucket-name", "/folder1///folder2/file.txt", "s3a://bucket-name//folder1///folder2/file.txt")]
+    public static void TrimsDuplicatedSlashes(string bucketName, string objectKey, string expected)
     {
         // Arrange
-        const string path = "s3a://bucket-name/";
+        var path = bucketName;
 
         // Act
-        var storagePath = new AmazonS3StoragePath(path).Join("/folder1///folder2/file.txt");
+        var storagePath = new AmazonS3StoragePath(path).Join(objectKey);
 
         // Assert
-        Assert.Equal("s3a://bucket-name/folder1/folder2/file.txt", storagePath.ToHdfsPath());
+        Assert.Equal(expected, storagePath.ToHdfsPath());
     }
 }

--- a/test/Storage/AmazonS3BlobStoragePathTests.cs
+++ b/test/Storage/AmazonS3BlobStoragePathTests.cs
@@ -48,8 +48,8 @@ public class AmazonS3BlobStoragePathTests
 
     [Theory]
     [InlineData("s3a://bucket-name/", "/folder1///folder2/file.txt", "s3a://bucket-name//folder1///folder2/file.txt")]
-    [InlineData("s3a://bucket-name/", "folder1///folder2/file.txt", "s3a://bucket-name//folder1///folder2/file.txt")]
-    [InlineData("s3a://bucket-name", "folder1///folder2/file.txt", "s3a://bucket-name//folder1///folder2/file.txt")]
+    [InlineData("s3a://bucket-name/", "folder1///folder2/file.txt", "s3a://bucket-name/folder1///folder2/file.txt")]
+    [InlineData("s3a://bucket-name", "folder1///folder2/file.txt", "s3a://bucket-name/folder1///folder2/file.txt")]
     [InlineData("s3a://bucket-name", "/folder1///folder2/file.txt", "s3a://bucket-name//folder1///folder2/file.txt")]
     public static void TrimsDuplicatedSlashes(string bucketName, string objectKey, string expected)
     {


### PR DESCRIPTION
Part of https://github.com/SneaksAndData/arcane-stream-blob-storage/issues/41

## This PR implemented the following changes:
- Fixed the path normalization introduced in #96
- Rolled back changes in AdlsGen2Path.cs

## Additional changes
- Updated SnD.Sdk.Tests.csproj to dotnet 8.0 since I am not able to run .net 6.0 apps on Mac OS for some reason, I don't want to investigate.