### PR TITLE
Make the method `WithOwnerReference` public

### DIFF
--- a/src/SnD.Sdk/Kubernetes/KubernetesApiExtensions.cs
+++ b/src/SnD.Sdk/Kubernetes/KubernetesApiExtensions.cs
@@ -8,7 +8,6 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Akka.Util.Internal;
-using k8s;
 using k8s.Autorest;
 using k8s.Models;
 using Microsoft.Extensions.Logging;
@@ -483,7 +482,7 @@ namespace Snd.Sdk.Kubernetes
         /// <param name="kind">The kind of the owner object.</param>
         /// <param name="metadata">The metadata of the owner object.</param>
         /// <returns>The Kubernetes Job object with the added owner reference.</returns>
-        private static V1Job WithOwnerReference(this V1Job job, string apiVersion, string kind, V1ObjectMeta metadata)
+        public static V1Job WithOwnerReference(this V1Job job, string apiVersion, string kind, V1ObjectMeta metadata)
         {
             job.Metadata.OwnerReferences ??= new List<V1OwnerReference>();
             job.Metadata.OwnerReferences.Add(new V1OwnerReference(apiVersion, kind, metadata.Name,


### PR DESCRIPTION
The WithOwnerReference method should be made public. We set it this way in Arcane to allow a StreamDefinition to be the owner of a job that runs the stream.